### PR TITLE
fix(ci): generate release notes from pull request metadata

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Build application
         run: pnpm run build
 
-      - name: Generate release notes
-        run: pnpm run release:notes -- release-notes.md
-
       - name: Package release artifact
         env:
           RELEASE_ARCHIVE: StratagemHero-pr-${{ github.event.pull_request.number }}.zip
@@ -64,7 +61,6 @@ jobs:
           path: |
             StratagemHero-pr-${{ github.event.pull_request.number }}.zip
             nginx.conf
-            release-notes.md
           if-no-files-found: error
           retention-days: 1
 
@@ -99,12 +95,43 @@ jobs:
           name: release-package
           path: release-package
 
+      - name: Generate release notes
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
+          PR_MERGE_COMMIT: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          node --input-type=module <<'EOF'
+          import { writeFile } from 'node:fs/promises'
+          const description = (process.env.PR_BODY || '').trim() || '该 Pull Request 未提供变更说明。'
+          const releaseNotes = [
+            '## 变更说明',
+            '',
+            description,
+            '',
+            '## 合并信息',
+            '',
+            `- Pull Request：[#${process.env.PR_NUMBER}](${process.env.PR_URL})`,
+            `- 标题：${process.env.PR_TITLE}`,
+            `- 作者：@${process.env.PR_AUTHOR}`,
+            `- 合并时间：${process.env.PR_MERGED_AT || '未知'}`,
+            `- 合并提交：\`${process.env.PR_MERGE_COMMIT || '未知'}\``,
+            '',
+          ].join('\n')
+
+          await writeFile('release-notes.md', releaseNotes, 'utf8')
+          EOF
+
       - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ARCHIVE: release-package/StratagemHero-pr-${{ github.event.pull_request.number }}.zip
           NGINX_CONFIG: release-package/nginx.conf
-          RELEASE_NOTES: release-package/release-notes.md
+          RELEASE_NOTES: release-notes.md
           RELEASE_TAG: pr-${{ github.event.pull_request.number }}
           RELEASE_TARGET: ${{ github.event.pull_request.merge_commit_sha }}
           RELEASE_TITLE: >-


### PR DESCRIPTION
#### 📝 变更概述 (Summary)
调整生产工作流中的发布说明生成时机与数据来源，使发布说明基于 PR 元数据在发布包上传后生成，并直接用于创建或更新 Release。

#### 🤖 Agent 关键改动 (Agent Core Changes)
- **Prompt / 提示词**: 无
- **Tools / 技能集**: 无
- **编排与路由 (Orchestration)**: 无 Agent 编排变更
- **模型/参数配置**: 无

#### 🛠 常规代码与基础设施 (Code & Infra)
- 移除发布说明生成步骤对构建产物的依赖。
- 使用 PR 编号、标题、正文、作者、合并时间、合并提交和链接生成 `release-notes.md`。
- 更新 Release 创建流程，直接引用工作区中的发布说明文件。

#### 🧪 评测与效果验证 (Evals & Testing)
- [ ] **Eval Benchmark**: 不适用，无 Agent 评测变更。
- [ ] **边界/安全测试**: Not run (not requested)

#### ⚠️ 破坏性变更与潜在风险 (Breaking Changes & Risks)
- 发布说明生成逻辑从构建阶段移至发布包上传后，需确保 PR 事件上下文中的元数据可用。
- 其他下游 API、模型或 Agent 能力无变化。